### PR TITLE
Bumped jacoco version to 0.7.9

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -59,7 +59,7 @@
         <jpmml.model.version>1.1.16.wso2v1</jpmml.model.version>
         <jpmml.manager.version>1.1.16.wso2v2</jpmml.manager.version>
         <pmml.evaluator.version>1.1.16.wso2v2</pmml.evaluator.version>
-        <jacoco.plugin.version>0.7.8</jacoco.plugin.version>
+        <jacoco.plugin.version>0.7.9</jacoco.plugin.version>
     </properties>
 
     <dependencyManagement>


### PR DESCRIPTION
## Purpose
Standardizing the version of Jacoco plugin used

## Approach
Bumped Jacoco version to 0.7.9

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes