### PR TITLE
Checking the input compatibility with PMML definition in logical operator based models

### DIFF
--- a/component/src/main/java/org/wso2/extension/siddhi/gpl/execution/pmml/PmmlModelProcessor.java
+++ b/component/src/main/java/org/wso2/extension/siddhi/gpl/execution/pmml/PmmlModelProcessor.java
@@ -24,6 +24,7 @@ import org.jpmml.evaluator.Evaluator;
 import org.jpmml.evaluator.EvaluatorUtil;
 import org.jpmml.evaluator.FieldValue;
 import org.jpmml.evaluator.InputField;
+import org.jpmml.evaluator.InvalidResultException;
 import org.jpmml.evaluator.ModelEvaluator;
 import org.jpmml.evaluator.ModelEvaluatorFactory;
 import org.jpmml.evaluator.OutputField;
@@ -182,7 +183,12 @@ public class PmmlModelProcessor extends StreamProcessor {
                 default:
                     break;
             }
-            inData.put(inputField.getName(), inputField.prepare(String.valueOf(dataValue)));
+            try {
+                inData.put(inputField.getName(), inputField.prepare(String.valueOf(dataValue)));
+            } catch (InvalidResultException e) {
+                logger.error(String.format("Incompatible value for field: %s. Prediction might be erroneous.",
+                        inputField.getName()));
+            }
         }
 
         if (!inData.isEmpty()) {

--- a/docs/api/latest.md
+++ b/docs/api/latest.md
@@ -1,4 +1,4 @@
-# API Docs - v4.0.7
+# API Docs - v4.0.8-SNAPSHOT
 
 ## Pmml
 


### PR DESCRIPTION
## Purpose
> Adding check for the input value for compatibility with model definition

## Goals
> In some PMML models where the model has been trained on synthetic data or the data shows no relationship between the target values, the model tend to be created with basic logical operators. If a value which doesn't agree with the ruleset is given as an input, the prediction would be erroneous.

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes