### PR TITLE
Updating the jar hosted location in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Latest API Docs is <a target="_blank" href="https://wso2-extensions.github.io/si
 
 * You can use this extension in the latest <a target="_blank" href="https://github.com/wso2/product-sp/releases">WSO2 Stream Processor</a> that is a part of <a target="_blank" href="http://wso2.com/analytics?utm_source=gitanalytics&utm_campaign=gitanalytics_Jul17">WSO2 Analytics</a> offering, with editor, debugger and simulation support. 
 
-* You can use  this extension after copying the component <a target="_blank" href="https://github.com/wso2-extensions/siddhi-gpl-execution-pmml/releases">jar</a> to the `<STREAM_PROCESSOR_HOME>/lib` directory.
+* You can use  this extension after copying the component <a target="_blank" href="http://central.maven.org/maven2/org/wso2/extension/siddhi/gpl/execution/pmml/siddhi-gpl-execution-pmml/">jar</a> to the `<STREAM_PROCESSOR_HOME>/lib` directory.
 
 **Using the extension as a <a target="_blank" href="https://wso2.github.io/siddhi/documentation/running-as-a-java-library">java library</a>**
 


### PR DESCRIPTION
## Purpose
Updating the jar hosted location in the README as extensions released under GPL licenses are not hosted in git. Fixes https://github.com/wso2-extensions/siddhi-gpl-execution-pmml/issues/30

## Goals
Pointing to the maven central download location

## Approach
b681b05

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes